### PR TITLE
Allow either start_date/end_date or start/end in schema.

### DIFF
--- a/events_schema.json
+++ b/events_schema.json
@@ -37,9 +37,7 @@
       "required": [
         "city",
         "country",
-        "end_date",
-        "name",
-        "start_date"
+        "name"
       ],
       "properties": {
         "bands": {
@@ -85,6 +83,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "start":  {
+          "type": "string",
+          "format": "date-time"
         },
         "name": {
           "description": "The name of the event.",


### PR DESCRIPTION
This doesn't enforce that exactly one is supplied, but it's an improvement over the status quo at least.

Fixes #10.