### PR TITLE
Ivan Aitken at Alcester weekend

### DIFF
--- a/events/uk/alcester_contra.yaml
+++ b/events/uk/alcester_contra.yaml
@@ -293,7 +293,7 @@ events:
       - Vertical Expression
     callers:
       - Seth Tepfer
-      - Geoff Cubitt
+      - Ivan Aitken
     price: £50
     organisation: Folk Dance Weekend
 


### PR DESCRIPTION
I believe Geoff has been replaced by Ivan for this weekend event (see https://www.folkdanceweekend.co.uk/alcester-american-dance-weekend/ accessed 2023-09-15)