### PR TITLE
Fix date for Jun 2024 EBW event

### DIFF
--- a/events/uk/eurobal_wessex.yaml
+++ b/events/uk/eurobal_wessex.yaml
@@ -255,7 +255,7 @@ events:
     price: £4-£6
     organisation: EuroBal Wessex
 
-  - name: EuroBal Wessex with Shivelight
+  - name: EuroBal Wessex
     links:
       - "https://www.facebook.com/events/842948303961646/"
     start: "2024-02-11T14:00:00+00:00"
@@ -287,7 +287,7 @@ events:
     price: £6-£10
     organisation: EuroBal Wessex
 
-  - name: Eurobal Wessex with Confluence
+  - name: Eurobal Wessex
     links:
       - "https://www.facebook.com/events/345624888338495/"
     start: "2024-06-02T14:00:00+01:00"

--- a/events/uk/eurobal_wessex.yaml
+++ b/events/uk/eurobal_wessex.yaml
@@ -255,7 +255,7 @@ events:
     price: £4-£6
     organisation: EuroBal Wessex
 
-  - name: EuroBal Wessex
+  - name: EuroBal Wessex with Shivelight
     links:
       - "https://www.facebook.com/events/842948303961646/"
     start: "2024-02-11T14:00:00+00:00"
@@ -287,11 +287,11 @@ events:
     price: £6-£10
     organisation: EuroBal Wessex
 
-  - name: Eurobal Wessex
+  - name: Eurobal Wessex with Confluence
     links:
       - "https://www.facebook.com/events/345624888338495/"
-    start: "2024-06-16T14:00:00+01:00"
-    end: "2024-06-16T17:30:00+01:00"
+    start: "2024-06-02T14:00:00+01:00"
+    end: "2024-06-02T17:30:00+01:00"
     country: UK
     city: Bournemouth
     styles:


### PR DESCRIPTION
The initial FB event for June 2024 was published to Facebook with the wrong date; https://www.facebook.com/events/345624888338495/ has now been corrected, so this PR updates this site to match.  Also highlighted EBW events with guest bands as opposed to those which are session-based