### PR TITLE
Update Simmelfolk festival to consolidate organisers

### DIFF
--- a/events/germany/simmelfolk.yaml
+++ b/events/germany/simmelfolk.yaml
@@ -2,7 +2,7 @@
 events:
   - name: Simmelfolk
     links:
-      - "https://simmelfolk-1.jimdosite.com/"
+      - "https://dckn.de/simmelfolk-festival/"
       - "https://www.facebook.com/events/2884443455191697/"
     start: 2022-09-16T16:00:00+02:00
     end: 2022-09-18T23:45:00+02:00
@@ -21,11 +21,11 @@ events:
       - Knopfgemurmel
       - Viorel
     price: €77-€99
-    organisation: Simmelfolk
+    organisation: Das co-kreative Netzwerk
 
   - name: Simmelfolk
     links:
-      - "https://simmelfolk-1.jimdosite.com/"
+      - "https://dckn.de/simmelfolk-festival/"
     start_date: 2023-09-15
     end_date: 2023-09-17
     country: Germany
@@ -40,7 +40,7 @@ events:
       - Luca Fiorini
       - Bassd scho
       - Emily & The Simons
-    organisation: Simmelfolk
+    organisation: Das co-kreative Netzwerk
 
   - name: Simmelfolk
     links:
@@ -54,4 +54,4 @@ events:
     workshop: true
     social: true
     price: €77-€120
-    organisation: Simmelfolk
+    organisation: Das co-kreative Netzwerk


### PR DESCRIPTION
A non-profit association was founded to host the Simmelfolk Festival and other Festivals (in Germany). Thus Simmelfolk festival was updated to reflect this change in organisation.

To make it consistent, also past events were updated (to allow for better filtering and searching).

In this process, also the website was moved and renewed, such that those links were updated too. The website of the new association can be found at https://dckn.de/.

The people behind the Simmelfolk festival are still the same, but the team got a bit bigger (including me now taking care of IT).

---

I am not fully aware, how the entries are organised here. Some appear to be by location, and some by festival name.
Be aware, that the DckN assosiation also hosts the events listed in [Chemnitz, Germany](https://github.com/qwandor/dancelist-data/blob/main/events/germany/chemnitz.yaml).
The closest bigger city to Simmelsdorf would be Nürnberg (write `nuernberg.yaml`) if there is a desire to consolidate here further.