### PR TITLE
update dates for Simmelfolk Festival 2025

### DIFF
--- a/events/germany/simmelfolk.yaml
+++ b/events/germany/simmelfolk.yaml
@@ -69,8 +69,8 @@ events:
   - name: Simmelfolk
     links:
       - "https://dckn.de/simmelfolk-festival/"
-    start: "2025-09-11T16:00:00+02:00"
-    end: "2025-09-15T02:00:00+02:00"
+    start: "2025-09-18T16:00:00+02:00"
+    end: "2025-09-21T02:00:00+02:00"
     country: Germany
     city: Simmelsdorf
     styles:


### PR DESCRIPTION
We had a change of date for Simmelfolk 2025.
https://dckn.de/co-kreative-projekte/simmelfolk-festival/